### PR TITLE
docs: .gitignore 파일에 필수 파일이 포함되어있어서 빌드가 안되는 문제 발생 -> 파일에서 .cproject와 …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # STM32CubeIDE / Eclipse
 .settings/
 .metadata/
-.cproject
-.project
 
 # Build output directories
 Debug/

--- a/Laser_Tank/.project
+++ b/Laser_Tank/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Laser_Tank</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
이 변경은 프로젝트 클론 후 빌드가 되지 않는 문제를 해결하기 위해 필수적입니다.
`.cproject`와 `.project` 파일이 `.gitignore`에 포함되어 있어 Git 저장소에 업로드되지 않아, 팀원들이 IDE에서 프로젝트를 올바르게 인식하지 
못했습니다.
이 변경으로 인해 모든 팀원이 동일한 빌드 환경을 공유하게 되고, 빌드가 가능해 질 것 입니다.